### PR TITLE
fix(src/capture-eye.ts): stop event propagation and default action for eye button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npm run lint
       - run: npm run build
       - run: npx playwright install
       - run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "rollup": "^2.73.0",
         "rollup-plugin-summary": "^1.4.3",
         "rollup-plugin-terser": "^7.0.2",
+        "sinon": "^18.0.0",
         "typescript": "~5.2.0"
       }
     },
@@ -2633,6 +2634,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "node_modules/@types/accepts": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.6.tgz",
@@ -4885,9 +4930,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
@@ -6730,6 +6775,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -7077,6 +7128,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
       "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -7474,6 +7531,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.0.tgz",
+      "integrity": "sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -8914,6 +8984,45 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
+      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9353,6 +9462,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -11758,6 +11876,52 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "@types/accepts": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.6.tgz",
@@ -13512,9 +13676,9 @@
       }
     },
     "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true
     },
     "dir-glob": {
@@ -14880,6 +15044,12 @@
       "integrity": "sha512-3KF80UaaSSxo8jVnRYtMKNGFOoVPBdkkVPsw+Ad0y4oxKXPduS6G6iHkrf69yJVff/VAaYXkV42rtZ7daJxU3w==",
       "dev": true
     },
+    "just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -15188,6 +15358,12 @@
       "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -15482,6 +15658,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "nise": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.0.tgz",
+      "integrity": "sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
+      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -16570,6 +16759,37 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "sinon": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
+      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16909,6 +17129,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.21.3",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "rollup": "^2.73.0",
     "rollup-plugin-summary": "^1.4.3",
     "rollup-plugin-terser": "^7.0.2",
+    "sinon": "^18.0.0",
     "typescript": "~5.2.0"
   },
   "customElements": "custom-elements.json"

--- a/src/capture-eye.ts
+++ b/src/capture-eye.ts
@@ -6,16 +6,6 @@ import { ModalManager } from './modal/modal-manager.js';
 import { CaptureEyeModal } from './modal/modal.js';
 import { MediaViewer } from './media-viewer/media-viewer.js';
 
-function loadFontFace() {
-  /*
-   * Inject link stylesheet to DOM directly since it will not work in shadow DOM
-   */
-  const font = document.createElement('link');
-  font.href = Constant.url.fontFaceCssUrl;
-  font.rel = 'stylesheet';
-  document.head.appendChild(font);
-}
-
 @customElement('capture-eye')
 export class CaptureEye extends LitElement {
   static override styles = getCaptureEyeStyles();
@@ -66,7 +56,7 @@ export class CaptureEye extends LitElement {
 
   constructor() {
     super();
-    loadFontFace();
+    this.loadFontFace();
     console.debug(MediaViewer.name); // The line ensures MediaViewer is included in compilation.
     console.debug(CaptureEyeModal.name); // The line ensures CaptureEyeModal is included in compilation.
   }
@@ -74,7 +64,7 @@ export class CaptureEye extends LitElement {
   buttonTemplate() {
     return this.nid
       ? html`
-          <div class="capture-eye-button" @click=${this.showModal}>
+          <div class="capture-eye-button" @click=${this.openEye}>
             <img src=${Constant.url.captureEyeIcon} alt="Capture Eye" />
           </div>
         `
@@ -98,7 +88,9 @@ export class CaptureEye extends LitElement {
     ModalManager.getInstance().initializeModal();
   }
 
-  private async showModal() {
+  openEye(event: Event) {
+    event.stopPropagation();
+    event.preventDefault();
     const modalManager = ModalManager.getInstance();
     const buttonElement = this.getButtonElement();
     const buttonRect = buttonElement.getBoundingClientRect();
@@ -138,6 +130,16 @@ export class CaptureEye extends LitElement {
         button.classList.remove('active');
       }
     }
+  }
+
+  private loadFontFace() {
+    /*
+     * Inject link stylesheet to DOM directly since it will not work in shadow DOM
+     */
+    const font = document.createElement('link');
+    font.href = Constant.url.fontFaceCssUrl;
+    font.rel = 'stylesheet';
+    document.head.appendChild(font);
   }
 }
 

--- a/src/modal/modal-styles.ts
+++ b/src/modal/modal-styles.ts
@@ -206,7 +206,7 @@ export function getModalStyles() {
       color: var(--secondary-text-color);
     }
 
-    .full-width-img {
+    .eng-img {
       width: 100%;
       display: block;
       border-bottom-left-radius: var(--border-radius);

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -3,7 +3,7 @@ import { customElement, property, state, query } from 'lit/decorators.js';
 import { getModalStyles } from './modal-styles.js';
 import { Constant } from '../constant.js';
 
-function formatTxHash(txHash: string): string {
+export function formatTxHash(txHash: string): string {
   if (txHash.length < 60) {
     return '';
   }
@@ -194,18 +194,16 @@ export class CaptureEyeModal extends LitElement {
                           >${formatTxHash(this.transaction)}</a
                         ></span
                       >`
-                  : html`<span
-                      >${this.transaction !== Constant.text.loading
-                        ? html`<img
-                              src=${Constant.url.txIcon}
-                              loading="lazy"
-                              width="20"
-                              height="Auto"
-                              alt=""
-                            />
-                            <span class="middle-text">Transaction: N/A</span>`
-                        : html`<div class="shimmer-text"></div>`}</span
-                    >`}
+                  : html`${this.transaction !== Constant.text.loading
+                      ? html`<img
+                            src=${Constant.url.txIcon}
+                            loading="lazy"
+                            width="20"
+                            height="Auto"
+                            alt=""
+                          />
+                          <span class="middle-text">Transaction: N/A</span>`
+                      : html`<span class="shimmer-text"></span>`}`}
               </div>`
           : html`<div class="middle-row">
               ${this.backendOwnerName !== Constant.text.loading
@@ -265,19 +263,23 @@ export class CaptureEyeModal extends LitElement {
             </div>
           </div>
           ${this.engagementImage && this.engagementLink
-            ? html`<a href=${this.engagementLink} target="_blank">
+            ? html`<a
+                href=${this.engagementLink}
+                target="_blank"
+                class="eng-link"
+              >
                 <img
                   src=${this.engagementImage}
                   alt="Full width"
-                  class="full-width-img"
+                  class="eng-img"
                   @load=${this.handleImageLoad}
                   style="display: ${this.imageLoaded ? 'block' : 'none'}"
                 />
                 ${!this.imageLoaded
-                  ? html`<div class="shimmer full-width-img"></div>`
+                  ? html`<div class="shimmer eng-img"></div>`
                   : ''}
               </a>`
-            : html`<div class="full-width-img"></div>`}
+            : html`<div class="eng-img"></div>`}
           <div class="close-button" @click=${this.hideModal}>
             <img src=${Constant.url.closeIcon} alt="Close" />
           </div>

--- a/src/test/capture-eye_test.ts
+++ b/src/test/capture-eye_test.ts
@@ -1,7 +1,7 @@
 import { CaptureEye } from '../capture-eye';
-
 import { fixture, assert } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
+import sinon from 'sinon';
 
 suite('capture-eye', () => {
   test('is defined', () => {
@@ -9,12 +9,118 @@ suite('capture-eye', () => {
     assert.instanceOf(el, CaptureEye);
   });
 
-  test('styling applied', async () => {
-    const el = (await fixture(html`<capture-eye></capture-eye>`)) as CaptureEye;
-    await el.updateComplete;
-    assert.equal(
-      getComputedStyle(el).fontFamily.includes('Degular-Medium'),
-      true
+  test('renders with default properties', async () => {
+    const el = await fixture<CaptureEye>(html`<capture-eye></capture-eye>`);
+    assert.shadowDom.equal(
+      el,
+      `
+      <div class="capture-eye-container">
+        <slot></slot>
+      </div>
+      `
     );
+  });
+
+  test('renders button when nid is set', async () => {
+    const el = await fixture<CaptureEye>(
+      html`<capture-eye nid="12345"></capture-eye>`
+    );
+    const button = el.shadowRoot?.querySelector('.capture-eye-button');
+    assert.isNotNull(button, 'Button should be rendered');
+  });
+
+  test('button click triggers openEye function', async () => {
+    const spy = sinon.spy(CaptureEye.prototype, 'openEye');
+    const el = await fixture<CaptureEye>(
+      html`<capture-eye nid="12345"></capture-eye>`
+    );
+    const button = el.shadowRoot?.querySelector('.capture-eye-button');
+    button?.dispatchEvent(new MouseEvent('click'));
+    assert.isTrue(spy.calledOnce, 'openEye should be called once');
+    spy.restore();
+  });
+
+  test('button active state changes on mouse enter/leave', async () => {
+    const el = await fixture<CaptureEye>(
+      html`<capture-eye nid="12345"><div></div></capture-eye>`
+    );
+    const button = el.shadowRoot?.querySelector(
+      '.capture-eye-button'
+    ) as HTMLElement;
+    const slot = el.shadowRoot?.querySelector('slot');
+
+    slot?.dispatchEvent(new MouseEvent('mouseenter'));
+    assert.isTrue(
+      button.classList.contains('active'),
+      `Button should be active on mouse enter`
+    );
+
+    slot?.dispatchEvent(new MouseEvent('mouseleave'));
+    assert.isFalse(
+      button.classList.contains('active'),
+      'Button should not be active on mouse leave'
+    );
+  });
+
+  test('loadFontFace function is called on initialization', async () => {
+    const spy = sinon.spy(CaptureEye.prototype as any, 'loadFontFace');
+    await fixture<CaptureEye>(html`<capture-eye></capture-eye>`);
+    assert.isTrue(spy.calledOnce, 'loadFontFace should be called once');
+    spy.restore();
+  });
+
+  test('clicking button invokes openEye but not outer div click', async () => {
+    const spyOpenEye = sinon.spy(CaptureEye.prototype, 'openEye');
+    const captureEye = await fixture(html`
+      <capture-eye nid="12345">
+        <div class="inner-div">Click me</div>
+      </capture-eye>
+    `);
+    const outerDiv = document.createElement('div');
+    outerDiv.appendChild(captureEye);
+    const button = captureEye.shadowRoot?.querySelector('.capture-eye-button');
+    const spyOuterDiv = sinon.spy();
+    outerDiv.addEventListener('click', spyOuterDiv);
+
+    // Click the button
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // Assert that openEye was called
+    assert.isTrue(spyOpenEye.calledOnce, 'openEye should be called once');
+
+    // Assert that the outer div click event was not triggered
+    assert.isFalse(
+      spyOuterDiv.called,
+      'Outer div click event should not be triggered'
+    );
+    spyOpenEye.restore();
+  });
+
+  test('clicking innter div invokes outer div click but not openEye', async () => {
+    const spyOpenEye = sinon.spy(CaptureEye.prototype, 'openEye');
+    const captureEye = await fixture(html`
+      <capture-eye nid="12345">
+        <div class="inner-div">Click me</div>
+      </capture-eye>
+    `);
+    const outerDiv = document.createElement('div');
+    outerDiv.appendChild(captureEye);
+    const innerDiv = outerDiv.querySelector('.inner-div');
+    if (!innerDiv) throw new Error('Inner div not found');
+    const spyOuterDiv = sinon.spy();
+    outerDiv.addEventListener('click', spyOuterDiv);
+
+    // Click the button
+    innerDiv.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // Assert that openEye was not called
+    assert.isFalse(spyOpenEye.called, 'openEye should not be called');
+
+    // Assert that the outer div click event was triggered once
+    assert.isTrue(
+      spyOuterDiv.calledOnce,
+      'Outer div click event should be triggered once'
+    );
+    spyOpenEye.restore();
   });
 });

--- a/src/test/modal_test.ts
+++ b/src/test/modal_test.ts
@@ -1,0 +1,123 @@
+import { html } from 'lit';
+import { fixture, assert } from '@open-wc/testing';
+import { CaptureEyeModal, formatTxHash } from '../modal/modal';
+
+suite('capture-eye-modal', () => {
+  test('is defined', () => {
+    const el = document.createElement('capture-eye-modal');
+    assert.instanceOf(el, CaptureEyeModal);
+  });
+
+  test('renders with default values', async () => {
+    const el = await fixture(html`<capture-eye-modal></capture-eye-modal>`);
+    assert.shadowDom.equal(
+      el,
+      `
+      <div class="modal modal-hidden">
+        <div class="modal-container">
+          <div class="modal-content">
+            <div class="card">
+              <div class="section">
+                <div class="section-title">Produced by</div>
+                <div class="profile-container">
+                  <div class="shimmer-profile-img"></div>
+                  <div class="profile-text">
+                    <div class="top-name">
+                      <div class="shimmer-text"></div>
+                    </div>
+                    <div class="top-date">
+                      <div class="shimmer-text"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="headline">
+                  <div class="shimmer-text"></div>
+                </div>
+              </div>
+              <div class="section">
+                <div class="section-title">Origins</div>
+                <div class="middle-row">
+                  <span class="shimmer-text"></span>
+                </div>
+                <div class="middle-row">
+                  <span class="shimmer-text"></span>
+                </div>
+              </div>
+              <div class="section">
+                <a href="https://verify.numbersprotocol.io/asset-profile/" target="_blank"><button class="view-more-btn">View More</button></a>
+                <div class="powered-by">
+                  <div class="shimmer-text"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="eng-img">
+          </div>
+          <div class="close-button close-button-hidden">
+            <img src="https://static-cdn.numbersprotocol.io/capture-eye/capture-eye-close-icon.png" alt="Close" />
+          </div>
+        </div>
+      </div>
+      `
+    );
+  });
+
+  test('handles modal visibility', async () => {
+    const el = await fixture<CaptureEyeModal>(
+      html`<capture-eye-modal class="modal-hidden"></capture-eye-modal>`
+    );
+    const modal = el.shadowRoot?.querySelector('.modal');
+    assert.isNotNull(modal);
+    assert.isTrue(modal?.classList.contains('modal-hidden'));
+
+    el.modalHidden = false;
+    await el.updateComplete;
+    assert.isFalse(modal?.classList.contains('modal-hidden'));
+    assert.isTrue(modal?.classList.contains('modal-visible'));
+  });
+
+  test('calls hideModal() when close button is clicked', async () => {
+    const el = await fixture<CaptureEyeModal>(
+      html`<capture-eye-modal></capture-eye-modal>`
+    );
+    const closeButton = el.shadowRoot?.querySelector(
+      '.close-button'
+    ) as HTMLElement;
+    assert.isNotNull(closeButton);
+
+    el.modalHidden = false;
+    await el.updateComplete;
+    closeButton.click();
+    await el.updateComplete;
+
+    const modal = el.shadowRoot?.querySelector('.modal');
+    assert.isTrue(modal?.classList.contains('modal-hidden'));
+    assert.isTrue(el.modalHidden);
+  });
+
+  test('renders engagement image and link correctly', async () => {
+    const engagementImage = 'https://example.com/image.jpg';
+    const engagementLink = 'https://example.com';
+    const el = await fixture<CaptureEyeModal>(html`
+      <capture-eye-modal></capture-eye-modal>
+    `);
+
+    el.engagementImage = engagementImage;
+    el.engagementLink = engagementLink;
+    await el.updateComplete;
+    const img = el.shadowRoot?.querySelector('.eng-img') as HTMLImageElement;
+    assert.isNotNull(img);
+    assert.equal(img.src, engagementImage);
+
+    const link = el.shadowRoot?.querySelector('.eng-link') as HTMLAnchorElement;
+    assert.isNotNull(link);
+    assert.equal(new URL(link.href).href, new URL(engagementLink).href);
+  });
+
+  test('correctly formats transaction hash', () => {
+    const txHash =
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+    const formatted = formatTxHash(txHash);
+    assert.equal(formatted, '0x1234...abcdef');
+  });
+});


### PR DESCRIPTION
## Fixed
- Clicking on Capture Eye button will not emit click event for parent node
- Clicking on Capture Eye slot (e.g. image) will keep emit click event for parent node, useful for the case the `<a>` tag wrapping Capture Eye to allow user to click the image and open a link

## Test
- Added basic unit tests
- Added test cases for the stop event propagation feature