### PR TITLE
fix: fix image loading issue caused by set imageLoaded to false in resetModalProps

### DIFF
--- a/src/modal/modal-manager.ts
+++ b/src/modal/modal-manager.ts
@@ -48,10 +48,12 @@ export class ModalManager {
         this.modalElement.resetModalProps();
         this.modalElement.nid = nid;
         this.modalElement.layout = layout;
-        this.modalElement.engagementImage = engagementImage;
-        this.modalElement.engagementLink = engagementLink;
-        this.modalElement.actionButtonText = actionButtonText;
-        this.modalElement.actionButtonLink = actionButtonLink;
+        this.modalElement.updateEngagementZone(
+          engagementImage,
+          engagementLink,
+          actionButtonText,
+          actionButtonLink
+        );
         fetchAsset(nid).then((assetData) =>
           this.updateModalAsset(assetData, true)
         );

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -63,10 +63,6 @@ export class CaptureEyeModal extends LitElement {
   }
 
   resetModalProps() {
-    this.engagementImage = Constant.url.defaultEngagementImage;
-    this.engagementLink = Constant.url.defaultEngagementLink;
-    this.actionButtonText = '';
-    this.actionButtonLink = '';
     this._blockchain = Constant.text.numbersMainnet;
     this._asset = undefined;
     this._assetLoaded = false;

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -46,6 +46,22 @@ export class CaptureEyeModal extends LitElement {
     if (setAsLoaded) this._assetLoaded = true;
   }
 
+  updateEngagementZone(
+    engagementImage: string,
+    engagementLink: string,
+    actionButtonText: string,
+    actionButtonLink: string
+  ) {
+    if (this.engagementImage !== engagementImage) {
+      this._imageLoaded = false;
+      this.engagementImage = engagementImage;
+      this.requestUpdate();
+    }
+    this.engagementLink = engagementLink;
+    this.actionButtonText = actionButtonText;
+    this.actionButtonLink = actionButtonLink;
+  }
+
   resetModalProps() {
     this.engagementImage = Constant.url.defaultEngagementImage;
     this.engagementLink = Constant.url.defaultEngagementLink;
@@ -54,7 +70,6 @@ export class CaptureEyeModal extends LitElement {
     this._blockchain = Constant.text.numbersMainnet;
     this._asset = undefined;
     this._assetLoaded = false;
-    this._imageLoaded = false;
   }
 
   override firstUpdated() {
@@ -274,6 +289,7 @@ export class CaptureEyeModal extends LitElement {
 
   private handleImageLoad() {
     this._imageLoaded = true;
+    console.log('imageLoaded', this._imageLoaded);
   }
 
   override render() {


### PR DESCRIPTION
## Fixed
- Fixed an issue causing engagement zone image infinitely loading when clicking on other Capture Eyes with same eng image