### PR TITLE
feat(plugins/wordpress/capture-eye): visibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ dev
 docs
 docs-src
 examples
+plugins
 test
 .eleventy.cjs
 .vscode

--- a/plugins/wordpress/capture-eye/capture-eye.php
+++ b/plugins/wordpress/capture-eye/capture-eye.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Capture Eye
  * Description: Capture Eye WordPress plugin.
- * Version:     0.0.1
+ * Version:     0.0.2
  * Author:      Numbers Protocol
  * Author URI:  https://www.numbersprotocol.io/
  */
@@ -27,7 +27,7 @@ function capture_eye_script_dependencies() {
 		'script-capture-eye',
 		'https://cdn.jsdelivr.net/npm/@numbersprotocol/capture-eye@latest/dist/capture-eye.bundled.js',
 		[],
-		'0.0.1',
+		'0.0.2',
 	);
 	wp_enqueue_script( 'script-capture-eye' );
 	add_filter( 'script_loader_tag', function($tag, $handle, $src) {

--- a/plugins/wordpress/capture-eye/includes/elementor-image-widget.php
+++ b/plugins/wordpress/capture-eye/includes/elementor-image-widget.php
@@ -120,6 +120,22 @@ class Elementor_Widget_Capture_Eye_Image extends \Elementor\Widget_Image {
 		);
 
 		$this->add_control(
+			'capture_eye_visibility',
+			[
+				'label' => esc_html__( 'Visibility', 'elementor-capture-eye-widget' ),
+				'type' => \Elementor\Controls_Manager::SELECT,
+				'options' => [
+					'hover' => esc_html__( 'Hover', 'elementor-capture-eye-widget' ),
+					'always' => esc_html__( 'Always', 'elementor-capture-eye-widget' ),
+				],
+				'default' => 'hover',
+				'condition' => [
+					'nid!' => '',
+				],
+			]
+		);
+
+		$this->add_control(
 			'eng_img',
 			[
 				'label' => esc_html__( 'Engagement zone banner image', 'elementor-capture-eye-widget' ),
@@ -218,6 +234,7 @@ class Elementor_Widget_Capture_Eye_Image extends \Elementor\Widget_Image {
 		<capture-eye
 			nid="<?php echo $nid; ?>"
 			layout="<?php echo $settings['capture_eye_layout']; ?>"
+			visibility="<?php echo $settings['capture_eye_visibility']; ?>"
 			<?php if ( $settings['eng_img']['url'] ) { ?>
 				eng-img="<?php echo $settings['eng_img']['url']; ?>"
 			<?php } ?>
@@ -277,6 +294,7 @@ class Elementor_Widget_Capture_Eye_Image extends \Elementor\Widget_Image {
 			#><capture-eye
 				nid="{{ nid }}"
 				layout="{{ settings.capture_eye_layout }}"
+				visibility="{{ settings.capture_eye_visibility }}"
 				<# if ( settings.eng_img.url ) {
 					#> eng-img="{{ settings.eng_img.url }}"
 				<# } #>


### PR DESCRIPTION
## Added
- Capture Eye WordPress plugin supports attribute visibility.