### PR TITLE
feat(src): add attribute to display abstract

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -94,11 +94,12 @@
       </capture-eye>
 
       <capture-eye
-        nid="bafybeidmy3oncdegri3cugy3zstnqderjokmj5f3wfqrbrswhcf47eyxau"
+        nid="bafybeigda2fjjeta7725hbicpfzldygszl4gbllcaybwuetlemraauazwm"
         position="top right"
+        heading-source="abstract"
       >
         <img
-          src="https://ipfs-pin.numbersprotocol.io/ipfs/bafybeidmy3oncdegri3cugy3zstnqderjokmj5f3wfqrbrswhcf47eyxau"
+          src="https://ipfs-pin.numbersprotocol.io/ipfs/bafybeigda2fjjeta7725hbicpfzldygszl4gbllcaybwuetlemraauazwm"
         />
       </capture-eye>
 

--- a/src/asset/asset-model.ts
+++ b/src/asset/asset-model.ts
@@ -4,6 +4,7 @@ export interface AssetModel {
   createdTime?: string;
   encodingFormat?: string;
   headline?: string;
+  abstract?: string;
   initialTransaction?: string;
   thumbnailUrl?: string;
   explorerUrl?: string;

--- a/src/asset/asset-service.ts
+++ b/src/asset/asset-service.ts
@@ -46,6 +46,7 @@ export async function fetchAsset(nid: string): Promise<AssetModel | undefined> {
       createdTime: data.assetTimestampCreated,
       encodingFormat: data.fullAssetTree?.['_api_c2_assetTree.encodingFormat'],
       headline: data.headline,
+      abstract: data.abstract,
       initialTransaction: data.initial_transaction,
       thumbnailUrl: data.thumnail_url, // [sic]
       explorerUrl: data.initial_transaction

--- a/src/capture-eye.ts
+++ b/src/capture-eye.ts
@@ -45,6 +45,12 @@ export class CaptureEye extends LitElement {
   color = '';
 
   /**
+   * Set heading source. Default is headline. Options: headline, abstract
+   */
+  @property({ type: String , attribute: 'heading-source' })
+  headingSource = '';
+
+  /**
    * Customizable copyright zone title.
    */
   @property({ type: String, attribute: 'cz-title' })
@@ -187,6 +193,7 @@ export class CaptureEye extends LitElement {
       nid: this.nid,
       layout: this.layout,
       color: this.color,
+      headingSource: this.headingSource,
       copyrightZoneTitle: this.copyrightZoneTitle,
       engagementZones: this.engagementZones,
       actionButtonText: this.actionButtonText,

--- a/src/modal/modal-styles.ts
+++ b/src/modal/modal-styles.ts
@@ -173,11 +173,21 @@ export function getModalStyles() {
       font-size: var(--font-size-very-small);
     }
 
-    .headline {
+    .heading {
       font-family: var(--font-light);
       color: var(--secondary-text-color);
       margin-bottom: 1rem;
       font-size: var(--font-size-small);
+      overflow: hidden;
+      max-height: 100px;
+      display: -webkit-box;
+      -webkit-line-clamp: 5;
+      -webkit-box-orient: vertical;
+    }
+
+    .heading.expand {
+      max-height: none;
+      -webkit-line-clamp: none;
     }
 
     .middle-row {

--- a/src/test/modal_test.ts
+++ b/src/test/modal_test.ts
@@ -43,7 +43,7 @@ suite('capture-eye-modal', () => {
                     </div>
                   </div>
                 </div>
-                <div class="headline">
+                <div class="heading headline" title="">
                   <div
                     class="shimmer-text"
                     style="height: auto;"
@@ -421,6 +421,7 @@ suite('capture-eye-modal', () => {
       captureTime: '2024-10-16',
       captureLocation: 'New York, USA',
       headline: 'Sample Asset',
+      abstract: 'A brief summary',
       initialTransaction:
         '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
       explorerUrl: 'https://example.com/explorer',
@@ -443,8 +444,8 @@ suite('capture-eye-modal', () => {
     ) as HTMLElement;
     expect(location.textContent?.trim()).to.equal(assetData.captureLocation);
 
-    const headline = el.shadowRoot?.querySelector('.headline') as HTMLElement;
-    expect(headline.textContent?.trim()).to.equal(assetData.headline);
+    const heading = el.shadowRoot?.querySelector('.heading') as HTMLElement;
+    expect(heading.textContent?.trim()).to.equal(assetData.headline);
 
     const img = el.shadowRoot?.querySelector(
       '.profile-img'
@@ -456,6 +457,16 @@ suite('capture-eye-modal', () => {
     );
 
     expect(badge).to.null;
+
+    // Headling source is abstract
+    el.updateModalOptions({
+      nid: '123',
+      headingSource: 'abstract'
+    });
+
+    await el.updateComplete;
+
+    expect(heading.textContent?.trim()).to.equal(assetData.abstract);
   });
 
   test('should render generated via AI correctly', async () => {


### PR DESCRIPTION
## Added

- New attribute `heading-source` allows setting `abstract` to display the abstract instead of the default `headline`.