### PR TITLE
Update IPFS links in capture-eye

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ on: ['push', 'pull_request']
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # playwright requires 22.04 for node 18.x and 20.x (playwirght 1.39.0)
+    # for 24.04, playwright 1.59.0 is required
+    # https://github.com/microsoft/playwright/issues/30368#issuecomment-2669259798
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/src/capture-eye.ts
+++ b/src/capture-eye.ts
@@ -78,8 +78,9 @@ export class CaptureEye extends LitElement {
     return `${Constant.url.ipfsGateway}/${this.nid}`;
   }
 
+  // This link is constructed for project needs
   get assetProfileUrl() {
-    return `${Constant.url.profile}/${this.nid}`;
+    return `${Constant.url.ipfsGateway}/${this.nid}`;
   }
 
   constructor() {


### PR DESCRIPTION
Update the `assetProfileUrl` getter to use the IPFS gateway URL and `nid`.

* Add a comment above the `assetProfileUrl` getter to indicate that the link is constructed for project needs

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/numbersprotocol/capture-eye/pull/57?shareId=5692a6c6-290f-4f2d-bb98-9239a263f0a1).