### PR TITLE
[Omni] Enable OIDC npm publishing for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Build the project

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://npm.pkg.github.com/
           scope: '@numbersprotocol'
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Build the project

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -43,11 +43,14 @@ jobs:
     needs: version-check
     if: needs.version-check.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           scope: '@numbersprotocol'
       - name: Install dependencies
@@ -56,8 +59,6 @@ jobs:
         run: MODE=prod npm run build
       - name: Deploy to NPM registry
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   purge-cdn-cache:
     needs: publish-npm

--- a/.omni/af42200c-github-npm/memory.md
+++ b/.omni/af42200c-github-npm/memory.md
@@ -1,0 +1,22 @@
+# Workspace Context
+
+<!-- This file is auto-maintained. The Repositories section is refreshed -->
+<!-- by the system. The AI should maintain Environment & Key Discoveries. -->
+
+**Workspace root (absolute path):** `/home/workspaces/conversations/af42200c-bf31-4914-9f0b-af6eacf96600`
+
+## Repositories
+
+- **`capture-eye/`** — Branch: `omni/af42200c/capture-eye`, Remote: `numbersprotocol/capture-eye`
+  - [![](https://data.jsdelivr.com/v1/package/npm/@numbersprotocol/capture-eye/badge?style=rounded)](https://www.jsdelivr.com/package/npm/@numbersprotocol/capture-eye)
+
+## Environment & Tools
+
+- Local runtime observed: Node v22.13.0, npm 10.9.2; npm Trusted Publishing requires npm CLI 11.5.1+ and Node 22.14.0+.
+
+## Key Discoveries
+
+- `capture-eye/.github/workflows/production-release.yml` publishes `@numbersprotocol/capture-eye` to npm from the `publish-npm` job using npm Trusted Publishing/OIDC; npm package is configured with GitHub Actions trusted publisher.
+
+---
+_Last system refresh: 2026-05-04 07:40 UTC_

--- a/.omni/af42200c-github-npm/memory.md
+++ b/.omni/af42200c-github-npm/memory.md
@@ -13,10 +13,11 @@
 ## Environment & Tools
 
 - Local runtime observed: Node v22.13.0, npm 10.9.2; npm Trusted Publishing requires npm CLI 11.5.1+ and Node 22.14.0+.
+- GitHub Actions release workflows use Node 24; CI matrix covers Node 20.x, 22.x, and 24.x.
 
 ## Key Discoveries
 
 - `capture-eye/.github/workflows/production-release.yml` publishes `@numbersprotocol/capture-eye` to npm from the `publish-npm` job using npm Trusted Publishing/OIDC; npm package is configured with GitHub Actions trusted publisher.
 
 ---
-_Last system refresh: 2026-05-04 07:40 UTC_
+_Last system refresh: 2026-05-04 07:48 UTC_

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
   ],
   "author": "Numbers Protocol",
   "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/numbersprotocol/capture-eye.git"
+  },
   "dependencies": {
     "lit": "^3.0.0"
   },


### PR DESCRIPTION
## Summary

Switch the production npm release workflow to use npm Trusted Publishing via GitHub OIDC instead of relying on the long-lived `NPM_TOKEN` secret. This aligns the release process for `@numbersprotocol/capture-eye` with npm’s recommended CI/CD authentication model and reduces token rotation overhead. The CI and release workflows now also include Node.js 24 to keep the GitHub Actions Node environment consistent with current runtime support.

## Changes

- Updated `.github/workflows/production-release.yml` to grant OIDC permissions and publish to npm without `NPM_TOKEN`.
- Updated `.github/workflows/build.yml` to add Node.js `24.x` to the CI matrix.
- Updated `.github/workflows/dev-release.yml` to run release steps on Node.js 24.
- Updated `package.json` with npm package publishing configuration for `@numbersprotocol/capture-eye`.
- Added implementation notes in `.omni/af42200c-github-npm/memory.md`.

5 files changed, +35 additions, -7 deletions

<details>
<summary>File changes</summary>

```
.github/workflows/build.yml              |  2 +-
 .github/workflows/dev-release.yml        |  2 +-
 .github/workflows/production-release.yml | 11 ++++++-----
 .omni/af42200c-github-npm/memory.md      | 23 +++++++++++++++++++++++
 package.json                             |  4 ++++
```
</details>

---
Generated by Olga Shen with [Omni](https://omniai.one/)