### PR TITLE
Bump capture-eye to 1.11.1

### DIFF
--- a/.omni/af42200c-github-npm/memory.md
+++ b/.omni/af42200c-github-npm/memory.md
@@ -19,6 +19,7 @@
 
 - `capture-eye/.github/workflows/production-release.yml` publishes `@numbersprotocol/capture-eye` to npm from the `publish-npm` job using npm Trusted Publishing/OIDC; npm package is configured with GitHub Actions trusted publisher.
 - npm vulnerability fix on 2026-05-04 only required `package-lock.json` updates for transitive dev dependencies: `brace-expansion`, `path-to-regexp`, and `smol-toml`.
+- Version bump prepared on 2026-05-04 updates `@numbersprotocol/capture-eye` from 1.11.0 to 1.11.1 in both `package.json` and `package-lock.json`; npm registry still shows 1.11.0 until the version bump lands on main and publishes.
 
 ---
-_Last system refresh: 2026-05-04 08:06 UTC_
+_Last system refresh: 2026-05-04 08:28 UTC_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numbersprotocol/capture-eye",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numbersprotocol/capture-eye",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "GPL-3.0",
       "dependencies": {
         "lit": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numbersprotocol/capture-eye",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Capture Eye widget seamlessly integrates into your website, facilitating secure and transparent provenance display and purchases of digital content directly from the creator",
   "main": "dist/capture-eye.js",
   "module": "dist/capture-eye.js",


### PR DESCRIPTION
## Summary

Bump `@numbersprotocol/capture-eye` from `1.11.0` to `1.11.1` so the production release workflow can detect a version change and run the publish jobs.

## Changes

- Update `package.json` version to `1.11.1`.
- Update `package-lock.json` root package version to `1.11.1`.

## Verification

- `npm audit --audit-level=moderate`
- `npm run lint`
- `npm run build`
- `npm run build:test`

## Release Notes

After this PR is merged to `main`, the Production Release workflow should run `publish-npm` because the package version has changed.

---
Generated by Olga Shen with [Omni](https://omniai.one/)